### PR TITLE
Add season points chart UI

### DIFF
--- a/tabs/season.py
+++ b/tabs/season.py
@@ -1,8 +1,20 @@
-"""Season overview placeholder tab."""
+"""Season overview tab displaying team points."""
+
+from __future__ import annotations
+
+import datetime
 
 import streamlit as st
 
+from utils.season import team_points_chart
 
-def render():
-    st.title("Season")
-    st.write("Season overview will go here.")
+
+def render() -> None:
+    """Render the season overview with team points chart."""
+    st.title("Season Team Points")
+
+    years = list(range(2018, datetime.date.today().year + 1))
+    year = st.selectbox("Year", years, index=len(years) - 1)
+
+    fig = team_points_chart(year)
+    st.plotly_chart(fig, use_container_width=True)


### PR DESCRIPTION
## Summary
- expand Season tab to display team points
- provide year selector in Season tab

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684ab126239c8333b37a232502a819c5