### PR TITLE
Add telemetry tab

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,7 +2,7 @@
 
 import fastf1
 import streamlit as st
-from tabs import circuit, driver, season
+from tabs import circuit, driver, season, telemetry
 
 # Enable on-disk caching for FastF1. This significantly speeds up repeated data
 # access by storing session data locally. The directory will be created if it
@@ -18,7 +18,12 @@ def main():
 
     st.sidebar.title("F1 Dashboard")
 
-    tab_driver, tab_season, tab_circuit = st.tabs(["Driver", "Season", "Circuit"])
+    tab_driver, tab_season, tab_circuit, tab_telemetry = st.tabs([
+        "Driver",
+        "Season",
+        "Circuit",
+        "Telemetry",
+    ])
 
     with tab_driver:
         driver.render()
@@ -28,6 +33,9 @@ def main():
 
     with tab_circuit:
         circuit.render()
+
+    with tab_telemetry:
+        telemetry.render()
 
 
 if __name__ == "__main__":

--- a/tabs/telemetry.py
+++ b/tabs/telemetry.py
@@ -1,0 +1,41 @@
+"""Driver telemetry comparison tab."""
+
+from __future__ import annotations
+
+import datetime
+
+import fastf1
+import streamlit as st
+
+from utils.telemetry import compare_fastest_lap_telemetry
+
+
+def _get_drivers(year: int, event: str) -> list[str]:
+    """Return a list of driver abbreviations for a given race."""
+    session = fastf1.get_session(year, event, "R")
+    session.load()  # type: ignore
+    return session.results["Abbreviation"].dropna().sort_values().unique().tolist()
+
+
+def render() -> None:
+    """Render the telemetry comparison tab."""
+    st.title("Telemetry Comparison")
+
+    years = list(range(2018, datetime.date.today().year + 1))
+    year = st.selectbox("Year", years, index=len(years) - 1)
+
+    schedule = fastf1.get_event_schedule(year, include_testing=False)
+    races = schedule["EventName"].tolist()
+    race = st.selectbox("Race", races)
+
+    drivers = _get_drivers(year, race) if race else []
+    driver1 = st.selectbox("Driver 1", drivers)
+    driver2 = st.selectbox("Driver 2", drivers, index=1 if len(drivers) > 1 else 0)
+
+    if drivers:
+        speed_fig, throttle_fig, brake_fig = compare_fastest_lap_telemetry(
+            year, race, "R", driver1, driver2
+        )
+        st.plotly_chart(speed_fig, use_container_width=True)
+        st.plotly_chart(throttle_fig, use_container_width=True)
+        st.plotly_chart(brake_fig, use_container_width=True)


### PR DESCRIPTION
## Summary
- include a telemetry tab in the main Streamlit UI
- implement `tabs/telemetry.py` to compare fastest laps for two drivers

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ab391297083338e0ed6c29befecfc