### PR TITLE
Add F1 logo to sidebar

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,6 +18,10 @@ def main():
         layout="wide",
     )
 
+    st.sidebar.image(
+        "https://upload.wikimedia.org/wikipedia/commons/3/33/F1.svg",
+        width=150,
+    )
     st.sidebar.title("F1 Dashboard")
 
     tab_driver, tab_season, tab_circuit, tab_telemetry = st.tabs([


### PR DESCRIPTION
## Summary
- display the F1 logo in the sidebar using an image from Wikipedia

## Testing
- `pytest` *(fails: no tests)*

------
https://chatgpt.com/codex/tasks/task_e_684ac6bbcc3483338100b36d251bf6ef