### PR TITLE
Add driver metadata utility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastf1
 streamlit
 plotly
 pandas
+requests


### PR DESCRIPTION
## Summary
- provide a driver metadata fetcher with fallback data
- include requests in requirements

## Testing
- `python -m py_compile utils/driver.py`

------
https://chatgpt.com/codex/tasks/task_e_684ac7c83a848333b6069621c2da5dcf