### PR TITLE
Improve schedule error handling

### DIFF
--- a/tabs/circuit.py
+++ b/tabs/circuit.py
@@ -17,7 +17,12 @@ def render() -> None:
     years = list(range(2018, datetime.date.today().year + 1))
     current_year = years[-1]
 
-    schedule = fastf1.get_event_schedule(current_year, include_testing=False)
+    try:
+        schedule = fastf1.get_event_schedule(current_year, include_testing=False)
+    except Exception:
+        st.error("Unable to load event schedule. Check network connection.")
+        return
+
     circuits = schedule["EventName"].tolist()
     circuit = st.selectbox("Circuit", circuits, key="circuit_circuit")
 

--- a/tabs/driver.py
+++ b/tabs/driver.py
@@ -31,7 +31,12 @@ def render() -> None:
         key="driver_year",
     )
 
-    schedule = fastf1.get_event_schedule(year, include_testing=False)
+    try:
+        schedule = fastf1.get_event_schedule(year, include_testing=False)
+    except Exception:
+        st.error("Unable to load event schedule. Check network connection.")
+        return
+
     events = schedule["EventName"].tolist()
 
     drivers = _get_drivers(year, events[0]) if events else []

--- a/tabs/telemetry.py
+++ b/tabs/telemetry.py
@@ -29,7 +29,12 @@ def render() -> None:
         key="telemetry_year",
     )
 
-    schedule = fastf1.get_event_schedule(year, include_testing=False)
+    try:
+        schedule = fastf1.get_event_schedule(year, include_testing=False)
+    except Exception:
+        st.error("Unable to load event schedule. Check network connection.")
+        return
+
     races = schedule["EventName"].tolist()
     race = st.selectbox("Race", races, key="telemetry_race")
 

--- a/utils/driver.py
+++ b/utils/driver.py
@@ -12,6 +12,7 @@ import requests
 import pandas as pd
 import fastf1
 import plotly.express as px
+import streamlit as st
 
 from utils.data import load_session
 
@@ -187,17 +188,19 @@ def driver_metadata(year: int, driver: str) -> dict[str, Any]:
 
     try:
         schedule = fastf1.get_event_schedule(year, include_testing=False)
-        if not schedule.empty:
-            first_event = schedule.iloc[0]["EventName"]
-            session = load_session(year, first_event, "R")
-            results = session.results
-            if results is not None:
-                row = results[results["Abbreviation"] == driver]
-                if not row.empty:
-                    name = row.iloc[0].get("FullName") or row.iloc[0].get("Driver")
-                    team = row.iloc[0].get("TeamName")
     except Exception:
-        pass
+        st.error("Unable to load event schedule. Check network connection.")
+        schedule = None
+
+    if schedule is not None and not schedule.empty:
+        first_event = schedule.iloc[0]["EventName"]
+        session = load_session(year, first_event, "R")
+        results = session.results
+        if results is not None:
+            row = results[results["Abbreviation"] == driver]
+            if not row.empty:
+                name = row.iloc[0].get("FullName") or row.iloc[0].get("Driver")
+                team = row.iloc[0].get("TeamName")
 
     nationality = None
     dob: datetime.date | None = None

--- a/utils/season.py
+++ b/utils/season.py
@@ -5,6 +5,7 @@ from concurrent.futures import ThreadPoolExecutor
 import fastf1
 import pandas as pd
 import plotly.express as px
+import streamlit as st
 
 from utils.data import load_session
 
@@ -25,7 +26,12 @@ def load_first_session(year: int, session: str):
     fastf1.core.Session
         The loaded FastF1 session instance.
     """
-    schedule = fastf1.get_event_schedule(year, include_testing=False)
+    try:
+        schedule = fastf1.get_event_schedule(year, include_testing=False)
+    except Exception:
+        st.error("Unable to load event schedule. Check network connection.")
+        return None
+
     event_name = schedule.iloc[0]["EventName"]
     sess = fastf1.get_session(year, event_name, session)
     sess.load()  # type: ignore
@@ -46,7 +52,12 @@ def team_points_chart(year: int):
     plotly.graph_objs.Figure
         Bar chart showing aggregated team points for the season.
     """
-    schedule = fastf1.get_event_schedule(year, include_testing=False)
+    try:
+        schedule = fastf1.get_event_schedule(year, include_testing=False)
+    except Exception:
+        st.error("Unable to load event schedule. Check network connection.")
+        return px.bar()
+
     events = schedule["EventName"].tolist()
 
     team_points: dict[str, float] = {}


### PR DESCRIPTION
## Summary
- handle errors from `fastf1.get_event_schedule`
- show an error message and skip rendering schedule-dependent UI
- add similar guards in utility modules

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684ac9b83ff883338fc0f0e64dfe8135