### PR TITLE
Improve error handling

### DIFF
--- a/tabs/circuit.py
+++ b/tabs/circuit.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import datetime
 
 import fastf1
+import requests
 import streamlit as st
 
 from utils.circuit import lap_time_boxplot
@@ -19,8 +20,8 @@ def render() -> None:
 
     try:
         schedule = fastf1.get_event_schedule(current_year, include_testing=False)
-    except Exception:
-        st.error("Unable to load event schedule. Check network connection.")
+    except (fastf1.FastF1Error, requests.RequestException) as err:
+        st.warning(f"Failed to load event schedule: {err}")
         return
 
     circuits = schedule["EventName"].tolist()

--- a/tabs/driver.py
+++ b/tabs/driver.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import datetime
 
 import fastf1
+import requests
 import streamlit as st
 
 from utils.driver import lap_time_chart
@@ -33,8 +34,8 @@ def render() -> None:
 
     try:
         schedule = fastf1.get_event_schedule(year, include_testing=False)
-    except Exception:
-        st.error("Unable to load event schedule. Check network connection.")
+    except (fastf1.FastF1Error, requests.RequestException) as err:
+        st.warning(f"Failed to load event schedule: {err}")
         return
 
     events = schedule["EventName"].tolist()

--- a/tabs/telemetry.py
+++ b/tabs/telemetry.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import datetime
 
 import fastf1
+import requests
 import streamlit as st
 
 from utils.telemetry import compare_fastest_lap_telemetry
@@ -31,8 +32,8 @@ def render() -> None:
 
     try:
         schedule = fastf1.get_event_schedule(year, include_testing=False)
-    except Exception:
-        st.error("Unable to load event schedule. Check network connection.")
+    except (fastf1.FastF1Error, requests.RequestException) as err:
+        st.warning(f"Failed to load event schedule: {err}")
         return
 
     races = schedule["EventName"].tolist()

--- a/utils/circuit.py
+++ b/utils/circuit.py
@@ -8,8 +8,13 @@ from concurrent.futures import ThreadPoolExecutor
 
 import pandas as pd
 import plotly.express as px
+import fastf1
+import requests
+import logging
 
 from utils.data import load_session
+
+logger = logging.getLogger(__name__)
 
 
 @lru_cache(maxsize=32)
@@ -33,7 +38,8 @@ def lap_time_boxplot(circuit: str, years: Iterable[int]):
     def _load(y: int):
         try:
             return load_session(y, circuit, "R")
-        except Exception:
+        except (fastf1.FastF1Error, requests.RequestException) as err:
+            logger.warning("Failed to load session %s %s: %s", circuit, y, err)
             return None
 
     with ThreadPoolExecutor() as pool:

--- a/utils/season.py
+++ b/utils/season.py
@@ -5,6 +5,7 @@ from concurrent.futures import ThreadPoolExecutor
 import fastf1
 import pandas as pd
 import plotly.express as px
+import requests
 import streamlit as st
 
 from utils.data import load_session
@@ -28,8 +29,8 @@ def load_first_session(year: int, session: str):
     """
     try:
         schedule = fastf1.get_event_schedule(year, include_testing=False)
-    except Exception:
-        st.error("Unable to load event schedule. Check network connection.")
+    except (fastf1.FastF1Error, requests.RequestException) as err:
+        st.warning(f"Failed to load event schedule: {err}")
         return None
 
     event_name = schedule.iloc[0]["EventName"]
@@ -54,8 +55,8 @@ def team_points_chart(year: int):
     """
     try:
         schedule = fastf1.get_event_schedule(year, include_testing=False)
-    except Exception:
-        st.error("Unable to load event schedule. Check network connection.")
+    except (fastf1.FastF1Error, requests.RequestException) as err:
+        st.warning(f"Failed to load event schedule: {err}")
         return px.bar()
 
     events = schedule["EventName"].tolist()


### PR DESCRIPTION
## Summary
- handle FastF1 and network failures explicitly
- log warnings to help debug missing metadata

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684acb2989b88333a0311b837c5e6192